### PR TITLE
Make it compatible with Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@ The `gin` script parses the databases that live at `.git/index` in any Git repos
 
 ## Install
 
-    pip3 install gin
+    pip install gin
 
 Or clone this repo and use the `gin` script.
 
 Or download the script directly.
-
-The script requires Python 3.
 
 ## Use
 

--- a/gin
+++ b/gin
@@ -1,14 +1,16 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 "gin - a Git index file parser"
-version = "0.1.006"
 
 # https://github.com/git/git/blob/master/Documentation/technical/index-format.txt
 
+from __future__ import print_function
 import binascii
 import collections
 import json
 import mmap
 import struct
+
+version = "0.1.006"
 
 def check(boolean, message):
     if not boolean:
@@ -122,7 +124,7 @@ def parse(filename, pretty=True):
 
             padlen = (8 - (entrylen % 8)) or 8
             nuls = f.read(padlen)
-            check(set(nuls) == {0}, "padding contained non-NUL")
+            check(nuls == b'\x00' * padlen, "padding contained non-NUL")
 
             yield entry
 

--- a/gin
+++ b/gin
@@ -10,7 +10,7 @@ import json
 import mmap
 import struct
 
-version = "0.1.006"
+version = "0.1.007"
 
 def check(boolean, message):
     if not boolean:

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ if __name__ == "__main__":
     README = "https://github.com/sbp/gin/blob/master/README.md"
 
     if os.path.isfile("gin"):
-        with open("gin", "r+", encoding="ascii") as f:
-            f.seek(66)
+        with open("gin", "r+b") as f:
+            f.seek(261)
             version = f.read(7)
 
             if os.path.isdir(".git") and ("sdist" in sys.argv):
@@ -18,7 +18,7 @@ if __name__ == "__main__":
                    raise ValueError("Update major/minor version")
                 version = version[:-3] + "%03i" % patch
 
-                f.seek(66)
+                f.seek(261)
                 f.write(version)
     else:
         print("Unable to find gin script: refusing to install")

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import distutils.core
 import os.path
@@ -37,5 +37,6 @@ if __name__ == "__main__":
             "Operating System :: MacOS :: MacOS X",
             "Operating System :: POSIX",
             "Programming Language :: Python :: 3"
+            "Programming Language :: Python :: 2"
         ]
     )


### PR DESCRIPTION
I think it's more convenient if gin supports both Python 2 and 3, so I send this pull request. It's your call.

Anyway, gin is good, I have used it many times these days. Thanks.
